### PR TITLE
Integrate Firebase into Flutter demo

### DIFF
--- a/flutter_demo/lib/firebase_options.dart
+++ b/flutter_demo/lib/firebase_options.dart
@@ -1,0 +1,13 @@
+import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
+
+class DefaultFirebaseOptions {
+  static const FirebaseOptions currentPlatform = FirebaseOptions(
+    apiKey: 'AIzaSyAwb70Myug06CMrwysQ-VNKIEoYs2D79sk',
+    appId: '1:685162092195:web:2ca6e28e622d10617f5116',
+    messagingSenderId: '685162092195',
+    projectId: 'stocks-d68d0',
+    authDomain: 'stocks-d68d0.firebaseapp.com',
+    storageBucket: 'stocks-d68d0.appspot.com',
+    measurementId: 'G-4ZZX9YJ6NL',
+  );
+}

--- a/flutter_demo/lib/main.dart
+++ b/flutter_demo/lib/main.dart
@@ -1,11 +1,36 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'firebase_options.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  final _actionController = TextEditingController();
+  final _amountController = TextEditingController();
+
+  Future<void> _save() async {
+    final action = _actionController.text;
+    final amount = double.tryParse(_amountController.text) ?? 0;
+    await FirebaseFirestore.instance.collection('portfolio').add({
+      'action': action,
+      'amount': amount,
+      'timestamp': FieldValue.serverTimestamp(),
+    });
+    _actionController.clear();
+    _amountController.clear();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -13,7 +38,49 @@ class MyApp extends StatelessWidget {
       title: 'SmartPortfolio Demo',
       home: Scaffold(
         appBar: AppBar(title: const Text('SmartPortfolio Demo')),
-        body: const Center(child: Text('Flutter web demo placeholder')),
+        body: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: [
+              TextField(
+                controller: _actionController,
+                decoration: const InputDecoration(labelText: 'Action'),
+              ),
+              TextField(
+                controller: _amountController,
+                decoration: const InputDecoration(labelText: 'Amount'),
+                keyboardType: TextInputType.number,
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton(onPressed: _save, child: const Text('Save')),
+              const SizedBox(height: 12),
+              Expanded(
+                child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+                  stream: FirebaseFirestore.instance
+                      .collection('portfolio')
+                      .orderBy('timestamp')
+                      .snapshots(),
+                  builder: (context, snapshot) {
+                    if (!snapshot.hasData) {
+                      return const Center(child: CircularProgressIndicator());
+                    }
+                    final docs = snapshot.data!.docs;
+                    return ListView(
+                      children: [
+                        for (final doc in docs)
+                          ListTile(
+                            title: Text(doc.data()['action'] ?? ''),
+                            subtitle: Text(
+                                (doc.data()['amount'] ?? '').toString()),
+                          )
+                      ],
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/flutter_demo/pubspec.yaml
+++ b/flutter_demo/pubspec.yaml
@@ -8,6 +8,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  firebase_core: ^2.13.0
+  cloud_firestore: ^4.8.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Firebase dependencies to the Flutter demo
- include firebase configuration in a new `firebase_options.dart`
- update the Flutter demo to initialize Firebase and store portfolio actions in Firestore

## Testing
- `python3 smartportfolio_cli.py` *(fails: EOF when reading a line)*

------
https://chatgpt.com/codex/tasks/task_e_68885864894c832d87027c590362f985