### PR TITLE
Document predict algorithm and add React demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ The `docs/` folder now contains a small React web demo that can be served via Gi
 
 If no build is present, the page shows a simple placeholder message. Integration with a Python backend will be added later.
 
+
+## Predict Algorithm
+
+See [docs/predict.md](docs/predict.md) for a description of the core predict function in both Danish and English.

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,18 +2,83 @@
 <html>
 <head>
   <meta charset="UTF-8" />
-  <title>SmartPortfolio React Demo</title>
+  <title>SmartPortfolio Predict Demo</title>
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <style>
     body { font-family: sans-serif; padding: 2em; }
+    label { display: block; margin-top: 0.5em; }
   </style>
 </head>
 <body>
   <div id="root"></div>
   <script type="text/javascript">
+    const { useState } = React;
+
+    const examplePortfolio = {
+      holdings: [
+        { ticker: 'AAPL', quantity: 10, price: 150 },
+        { ticker: 'TSLA', quantity: 5, price: 700 }
+      ],
+      cash: 2000
+    };
+
+    function predict(portfolio, prefs) {
+      const actionScore = prefs.risk === 'high' ? 80 : 40;
+      const transactions = actionScore > 70 ? [{ action: 'buy', ticker: 'MSFT', amount: 1000 }] : [];
+      return {
+        actionScore,
+        newPortfolio: portfolio,
+        transactions,
+        explanation: actionScore > 70 ?
+          'Market trend positive - consider buying MSFT' :
+          'Portfolio in good balance'
+      };
+    }
+
+    function App() {
+      const [risk, setRisk] = useState('medium');
+      const [horizon, setHorizon] = useState('medium');
+      const [result, setResult] = useState(null);
+
+      const handleRun = () => {
+        const prefs = { risk, horizon };
+        const res = predict(examplePortfolio, prefs);
+        setResult(res);
+      };
+
+      return React.createElement('div', null,
+        React.createElement('h1', null, 'SmartPortfolio Predict Demo'),
+        React.createElement('label', null, 'Risk level:',
+          React.createElement('select', { value: risk, onChange: e => setRisk(e.target.value) },
+            React.createElement('option', { value: 'low' }, 'Low'),
+            React.createElement('option', { value: 'medium' }, 'Medium'),
+            React.createElement('option', { value: 'high' }, 'High')
+          )
+        ),
+        React.createElement('label', null, 'Investment horizon:',
+          React.createElement('select', { value: horizon, onChange: e => setHorizon(e.target.value) },
+            React.createElement('option', { value: 'short' }, '<2 years'),
+            React.createElement('option', { value: 'medium' }, '2-5 years'),
+            React.createElement('option', { value: 'long' }, '>5 years')
+          )
+        ),
+        React.createElement('button', { onClick: handleRun, style: { marginTop: '1em' } }, 'Run Predict'),
+        result && React.createElement('div', { style: { marginTop: '1em' } },
+          React.createElement('h2', null, 'Result'),
+          React.createElement('p', null, 'Action score: ' + result.actionScore),
+          React.createElement('p', null, result.explanation),
+          result.transactions.length > 0 && React.createElement('ul', null,
+            result.transactions.map((t, i) =>
+              React.createElement('li', { key: i }, `${t.action} ${t.ticker} $${t.amount}`)
+            )
+          )
+        )
+      );
+    }
+
     const root = ReactDOM.createRoot(document.getElementById('root'));
-    root.render(React.createElement('h1', null, 'SmartPortfolio React Demo Coming Soon'));
+    root.render(React.createElement(App));
   </script>
 </body>
 </html>

--- a/docs/predict.md
+++ b/docs/predict.md
@@ -1,0 +1,40 @@
+# Predict-algoritmen
+
+## Dansk
+
+Predict-funktionen er hjertet i SmartPortfolio. Den tager udgangspunkt i brugerens nuværende portefølje, aktuelle markedsdata og investeringspræferencer. Resultatet er en opdateret portefølje samt en handleplan med vurdering af, om der bør foretages køb eller salg nu.
+
+Input til funktionen består af:
+
+- **Portefølje**: liste over beholdninger, kontantbeholdning, investeringshorisont, risikovillighed og eventuelle favoritter/fravalg.
+- **Markedsdata**: nøgletal, momentum, rente og nyhedssentiment.
+- **Brugerpræferencer**: stilvalg (value, vækst, udbytte, ESG), ønsket handelsfrekvens og kontantbuffer.
+
+Output er:
+
+1. **Handling-score** (0-100) der indikerer, om det er tid til at handle.
+2. **Ny porteføljesammensætning** med foreslåede vægte.
+3. **Transaktionsliste** over aktier der bør købes eller sælges.
+4. **Kort forklaring** på anbefalingen.
+
+Algoritmen kombinerer en simpel scoringsmodel med regler for spredning og risikostyring. I denne demo er logikken forenklet, men strukturen gør det let at udbygge med mere avancerede beregninger.
+
+## English
+
+The predict function is the core of SmartPortfolio. It analyzes the user's current portfolio along with market data and investment preferences. The output is an updated portfolio plus a recommended action plan indicating whether to buy or sell now.
+
+Input parameters include:
+
+- **Portfolio**: holdings, cash balance, investment horizon, risk level and any favorites/blacklist.
+- **Market data**: valuation metrics, momentum, interest rate and news sentiment.
+- **User preferences**: style (value, growth, dividend, ESG), desired trading frequency and cash buffer.
+
+The function returns:
+
+1. **Action score** (0-100) describing if trading is advised.
+2. **Revised portfolio composition** with suggested weights.
+3. **List of transactions** to buy or sell specific stocks.
+4. **Short explanation** of the recommendation.
+
+The algorithm uses a scoring model combined with rule-based checks for diversification and risk. This demo keeps the logic simple while leaving room for future improvements.
+

--- a/smartportfolio/predict.py
+++ b/smartportfolio/predict.py
@@ -1,0 +1,53 @@
+"""Simple predict algorithm for SmartPortfolio demo."""
+
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Holding:
+    ticker: str
+    quantity: int
+    purchase_price: float
+
+
+@dataclass
+class PortfolioInput:
+    holdings: List[Holding]
+    cash: float
+    horizon: str  # short, medium, long
+    risk: str  # low, medium, high
+    favorites: List[str] = field(default_factory=list)
+    blacklist: List[str] = field(default_factory=list)
+
+
+@dataclass
+class Transaction:
+    action: str  # "buy" or "sell"
+    ticker: str
+    amount: float
+
+
+@dataclass
+class PredictResult:
+    action_score: int
+    new_portfolio: PortfolioInput
+    transactions: List[Transaction]
+    explanation: str
+
+
+def predict(portfolio: PortfolioInput) -> PredictResult:
+    """Return a simple prediction based on risk level."""
+    score = 80 if portfolio.risk == "high" else 40
+    transactions: List[Transaction] = []
+    if score > 70:
+        transactions.append(Transaction(action="buy", ticker="MSFT", amount=1000))
+        explanation = "Market trend positive - consider buying MSFT"
+    else:
+        explanation = "Portfolio in good balance"
+    return PredictResult(
+        action_score=score,
+        new_portfolio=portfolio,
+        transactions=transactions,
+        explanation=explanation,
+    )


### PR DESCRIPTION
## Summary
- add English/Danish description of the predict function
- implement a simple predict demo in docs
- introduce `predict` module for future backend use
- reference the new docs from README

## Testing
- `python3 -m py_compile smartportfolio/*.py smartportfolio_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68885c5b518c832d8e01f44ad745680b