### PR TITLE
Document predict algorithm and add web demo

### DIFF
--- a/docs/PREDICT.md
+++ b/docs/PREDICT.md
@@ -1,0 +1,102 @@
+# Predict-funktionen / Predict Function
+
+## Dansk
+
+### Formål
+
+Predict-funktionen er hjertet i SmartPortfolio og tager udgangspunkt i brugerens nuværende portefølje, markedets tilstand og investeringsstil. Den returnerer en forbedret portefølje, en liste over anbefalede transaktioner samt en vurdering af, om det er et godt tidspunkt at handle.
+
+### Input
+1. **Portfolio**
+   - Beholdning: liste over aktier med ticker, antal, anskaffelseskurs og dato.
+   - Kontantbeholdning.
+   - Investeringshorisont (kort, mellem, lang).
+   - Risikovillighed (lav, mellem, høj).
+   - Favoritter / fravalg af aktier eller sektorer.
+2. **Market data**
+   - Aktuelle kurser og historiske bevægelser.
+   - Nøgletal (PE, PEG, ROIC, gæld, udbytte).
+   - Momentum (1, 3 og 6 måneder).
+   - Makroindikatorer (rente, sektorrotation).
+3. **Brugerpræferencer**
+   - Stilvalg: value, growth, stabilt udbytte eller ESG.
+   - Handelsfrekvens.
+   - Kontantbuffer.
+
+### Output
+1. **Handling-score** (0–100)
+   - 0–40: Vent
+   - 41–70: Overvej justering
+   - 71–100: Anbefalet handling
+2. **Revideret portefølje** med foreslåede vægte.
+3. **Transaktionsliste** over aktier der bør sælges eller købes.
+4. **Forklaring** i kort tekst.
+
+### Funktionalitet og logik
+Predict kombinerer en scoringsmodel og et regelsæt for at sikre spredning, kontantbuffer og maksimal eksponering. Hver aktie vurderes ud fra nøgletal, performance og om den matcher brugerens strategi.
+
+### Eksempelkald
+```python
+from smartportfolio.predict import predict, PortfolioInput, Stock
+
+portfolio = PortfolioInput(
+    holdings=[Stock(ticker="AAPL", quantity=10, purchase_price=150.0, purchase_date="2024-01-10")],
+    cash_balance=2500.0,
+    horizon="mellem",
+    risk="middel"
+)
+
+result = predict(portfolio)
+print(result)
+```
+
+---
+
+## English
+
+### Purpose
+The predict function forms the core of SmartPortfolio. It evaluates the current portfolio together with market conditions and the user’s investment style. The function returns an improved portfolio, a list of recommended transactions and a score indicating whether action should be taken now.
+
+### Input
+1. **Portfolio**
+   - Holdings: list of stocks with ticker, quantity, acquisition price and date.
+   - Cash balance.
+   - Investment horizon (short, medium, long).
+   - Risk appetite (low, medium, high).
+   - Favorites / exclusions of stocks or sectors.
+2. **Market data**
+   - Current prices and historical movements.
+   - Key ratios (PE, PEG, ROIC, debt, dividend).
+   - Momentum (1, 3 and 6 months).
+   - Macro indicators (interest rates, sector rotation).
+3. **User preferences**
+   - Style: value, growth, steady dividend or ESG.
+   - Trading frequency.
+   - Desired cash buffer.
+
+### Output
+1. **Action score** (0–100)
+   - 0–40: Hold
+   - 41–70: Consider adjustments
+   - 71–100: Action recommended
+2. **Revised portfolio** with suggested weights.
+3. **Transaction list** of stocks to sell or buy.
+4. **Explanation** in clear text.
+
+### Functionality and logic
+The predict function combines a scoring model and rule set to ensure diversification, cash buffer and maximum exposure. Each stock is rated by key figures, performance and fit with the user’s strategy.
+
+### Example call
+```python
+from smartportfolio.predict import predict, PortfolioInput, Stock
+
+portfolio = PortfolioInput(
+    holdings=[Stock(ticker="AAPL", quantity=10, purchase_price=150.0, purchase_date="2024-01-10")],
+    cash_balance=2500.0,
+    horizon="medium",
+    risk="medium"
+)
+
+result = predict(portfolio)
+print(result)
+```

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,19 +5,74 @@
   <title>SmartPortfolio React Demo</title>
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
   <style>
     body { font-family: sans-serif; padding: 2em; }
+    label { margin-right: 1em; }
   </style>
 </head>
 <body>
   <div id="root"></div>
   <script src="firebase.js"></script>
-  <script type="text/javascript">
+  <script type="text/babel">
+    function dummyPredict(input) {
+      return {
+        actionScore: 75,
+        explanation: 'Din eksponering mod tech er for h\u00f8j',
+        transactions: [
+          { action: 'buy', ticker: 'AAPL', amount: 2 },
+          { action: 'sell', ticker: 'TSLA', amount: 1 }
+        ]
+      };
+    }
+
+    function PredictDemo() {
+      const [risk, setRisk] = React.useState('medium');
+      const [cash, setCash] = React.useState(10);
+      const [result, setResult] = React.useState(null);
+
+      const handlePredict = () => {
+        const res = dummyPredict({ risk, cash });
+        setResult(res);
+      };
+
+      return (
+        <div>
+          <h1>SmartPortfolio React Demo (with Firebase)</h1>
+          <div>
+            <label>
+              Risk:
+              <select value={risk} onChange={e => setRisk(e.target.value)}>
+                <option value="low">low</option>
+                <option value="medium">medium</option>
+                <option value="high">high</option>
+              </select>
+            </label>
+            <label>
+              Cash %:
+              <input type="number" value={cash} onChange={e => setCash(e.target.value)} />
+            </label>
+            <button onClick={handlePredict}>Predict</button>
+          </div>
+          {result && (
+            <div>
+              <h2>Result</h2>
+              <p>Action score: {result.actionScore}</p>
+              <p>{result.explanation}</p>
+              <ul>
+                {result.transactions.map((t, i) => (
+                  <li key={i}>{t.action} {t.ticker} ({t.amount})</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      );
+    }
+
     const root = ReactDOM.createRoot(document.getElementById('root'));
-    root.render(
-      React.createElement('h1', null, 'SmartPortfolio React Demo (with Firebase)')
-    );
+    root.render(<PredictDemo />);
   </script>
 </body>
 </html>

--- a/smartportfolio/predict.py
+++ b/smartportfolio/predict.py
@@ -1,0 +1,58 @@
+"""Simplified predict algorithm for SmartPortfolio."""
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Stock:
+    ticker: str
+    quantity: int
+    purchase_price: float
+    purchase_date: str
+
+
+@dataclass
+class PortfolioInput:
+    holdings: List[Stock]
+    cash_balance: float
+    horizon: str
+    risk: str
+
+
+@dataclass
+class Transaction:
+    action: str  # "buy" or "sell"
+    ticker: str
+    amount: int
+    reason: str
+
+
+@dataclass
+class Prediction:
+    action_score: int
+    new_holdings: List[Stock]
+    transactions: List[Transaction]
+    explanation: str
+
+
+def predict(portfolio: PortfolioInput) -> Prediction:
+    """Return a dummy prediction based on the portfolio risk level."""
+    if portfolio.risk == "low":
+        score = 40
+        transactions: List[Transaction] = []
+        explanation = "Porteføljen ser stabil ud."
+    else:
+        score = 75
+        transactions = [
+            Transaction(action="sell", ticker="TSLA", amount=2, reason="High valuation"),
+            Transaction(action="buy", ticker="AAPL", amount=2, reason="Strong earnings"),
+        ]
+        explanation = "Ny kandidat passer bedre til din strategi."
+
+    return Prediction(
+        action_score=score,
+        new_holdings=portfolio.holdings,
+        transactions=transactions,
+        explanation=explanation,
+    )


### PR DESCRIPTION
## Summary
- describe the predict function in both Danish and English
- add example predict module
- enhance the docs React demo to accept input and show example output

## Testing
- `python3 -m py_compile smartportfolio/predict.py`

------
https://chatgpt.com/codex/tasks/task_e_68885d573e34832d9812b2ba97dabd65