### PR TITLE
Improve React demo UX

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,22 +8,33 @@
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
   <style>
-    body { font-family: sans-serif; padding: 2em; }
+    body { font-family: sans-serif; padding: 2em; transition: background 0.3s, color 0.3s; }
     label { margin-right: 1em; }
     .controls { display: flex; flex-wrap: wrap; gap: 1em; align-items: center; }
     .help { margin-left: 0.3em; cursor: help; border-bottom: 1px dotted; }
-    .result ul { list-style: none; padding: 0; }
-    .result li.buy { color: green; }
-    .result li.sell { color: red; }
+    .error { color: red; font-size: 0.9em; }
+    .spinner { border: 3px solid #f3f3f3; border-top: 3px solid #555; border-radius: 50%; width: 16px; height: 16px; display: inline-block; animation: spin 1s linear infinite; margin-right: 0.5em; }
+    @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+    table.transactions { border-collapse: collapse; width: 100%; margin-top: 0.5em; }
+    table.transactions th, table.transactions td { border: 1px solid #ccc; padding: 0.4em; text-align: left; }
+    table.transactions tr.buy { color: green; }
+    table.transactions tr.sell { color: red; }
     .score-bar { background: #eee; width: 100%; height: 1em; margin-bottom: 0.5em; }
     .score-bar .score { background: #4caf50; height: 100%; }
-    @media (max-width: 600px) { .controls { flex-direction: column; align-items: flex-start; } }
+    body.dark { background: #121212; color: #eee; }
+    body.dark .score-bar { background: #333; }
+    body.dark .score-bar .score { background: #81c784; }
+    body.dark table.transactions th, body.dark table.transactions td { border-color: #555; }
+    @media (max-width: 600px) {
+      .controls { flex-direction: column; align-items: stretch; }
+      .controls label, .controls button { width: 100%; }
+    }
   </style>
 </head>
 <body>
   <div id="root"></div>
   <script src="firebase.js"></script>
+  <script src="locales.js"></script>
   <script type="text/babel" src="app.jsx"></script>
 </body>
 </html>
-

--- a/docs/locales.js
+++ b/docs/locales.js
@@ -1,0 +1,30 @@
+window.locales = {
+  en: {
+    labels: {
+      risk: 'Risk',
+      cash: 'Cash %',
+      lang: 'Language',
+      predict: 'Predict',
+      predicting: 'Predicting...',
+      result: 'Result',
+      darkMode: 'Dark Mode',
+      actions: { buy: 'Buy', sell: 'Sell' },
+      cashError: 'Cash percentage must be between 0 and 100'
+    },
+    explanationTechTooHigh: 'Your exposure to tech is too high'
+  },
+  da: {
+    labels: {
+      risk: 'Risiko',
+      cash: 'Kontant %',
+      lang: 'Sprog',
+      predict: 'Beregn',
+      predicting: 'Beregner...',
+      result: 'Resultat',
+      darkMode: 'M\u00f8rk tilstand',
+      actions: { buy: 'K\u00f8b', sell: 'S\u00e6lg' },
+      cashError: 'Kontant procent skal v\u00e6re mellem 0 og 100'
+    },
+    explanationTechTooHigh: 'Din eksponering mod tech er for h\u00f8j'
+  }
+};


### PR DESCRIPTION
## Summary
- enhance usability of the React demo
  - locale strings moved to separate `locales.js`
  - add dark mode toggle
  - add spinner indicator and cash validation
  - present transactions in a table
  - responsive layout tweaks

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `node -e "require('fs').readFileSync('docs/app.jsx','utf8');"`

------
https://chatgpt.com/codex/tasks/task_e_688862808130832d8f125d6f1bdf48f6