### PR TITLE
Add exchange fees for transactions

### DIFF
--- a/docs/app.jsx
+++ b/docs/app.jsx
@@ -1,3 +1,10 @@
+const exchangeFees = {
+  NewYork: 0.1,
+  London: 0.5,
+  Tokyo: 0.3,
+  Frankfurt: 0.2
+};
+
 function dummyPredict(input, lang) {
   return new Promise(resolve => {
     setTimeout(() => {
@@ -5,8 +12,8 @@ function dummyPredict(input, lang) {
         actionScore: 75,
         explanation: window.locales[lang].explanationTechTooHigh,
         transactions: [
-          { action: 'buy', ticker: 'AAPL', amount: 2 },
-          { action: 'sell', ticker: 'TSLA', amount: 1 }
+          { action: 'buy', ticker: 'AAPL', amount: 2, exchange: 'NewYork' },
+          { action: 'sell', ticker: 'TSLA', amount: 1, exchange: 'London' }
         ]
       });
     }, 500);
@@ -49,6 +56,11 @@ function PredictDemo() {
     setLoading(false);
   };
 
+  const getTransactionCost = t => {
+    const fee = exchangeFees[t.exchange] || 0;
+    return (t.amount * fee) / 100;
+  };
+
   return (
     <div className="container">
       <h1>SmartPortfolio React Demo (with Firebase)</h1>
@@ -87,7 +99,7 @@ function PredictDemo() {
           <p className="explanation">{result.explanation}</p>
           <table className="transactions">
             <thead>
-              <tr><th>{t.actions.buy}/{t.actions.sell}</th><th>Ticker</th><th>Amt</th></tr>
+              <tr><th>{t.actions.buy}/{t.actions.sell}</th><th>Ticker</th><th>Amt</th><th>{t.cost}</th></tr>
             </thead>
             <tbody>
               {result.transactions.map((tItem, i) => (
@@ -95,6 +107,7 @@ function PredictDemo() {
                   <td>{tItem.action === 'buy' ? '✔️' : '❌'} {t.actions[tItem.action]}</td>
                   <td>{tItem.ticker}</td>
                   <td>{tItem.amount}</td>
+                  <td>{getTransactionCost(tItem).toFixed(2)}</td>
                 </tr>
               ))}
             </tbody>

--- a/docs/locales.js
+++ b/docs/locales.js
@@ -8,6 +8,7 @@ window.locales = {
       predicting: 'Predicting...',
       result: 'Result',
       darkMode: 'Dark Mode',
+      cost: 'Cost',
       actions: { buy: 'Buy', sell: 'Sell' },
       cashError: 'Cash percentage must be between 0 and 100'
     },
@@ -22,6 +23,7 @@ window.locales = {
       predicting: 'Beregner...',
       result: 'Resultat',
       darkMode: 'M\u00f8rk tilstand',
+      cost: 'Omkostning',
       actions: { buy: 'K\u00f8b', sell: 'S\u00e6lg' },
       cashError: 'Kontant procent skal v\u00e6re mellem 0 og 100'
     },


### PR DESCRIPTION
## Summary
- add exchange fee table and include exchange info in dummy predict
- calculate and display transaction cost in React demo
- translate 'Cost' label in English and Danish locales

## Testing
- `node -c docs/locales.js`

------
https://chatgpt.com/codex/tasks/task_e_68886b20c36c832d8b3c6431e3ae070c