### PR TITLE
Add demo portfolio data and table to React demo

### DIFF
--- a/docs/app.jsx
+++ b/docs/app.jsx
@@ -5,6 +5,13 @@ const exchangeFees = {
   Frankfurt: 0.2
 };
 
+function getHoldingsWithValue(portfolio) {
+  return portfolio.holdings.map(h => ({
+    ...h,
+    value: (h.weight / 100) * portfolio.invested
+  }));
+}
+
 function dummyPredict(input, lang) {
   return new Promise(resolve => {
     setTimeout(() => {
@@ -28,6 +35,7 @@ function PredictDemo() {
   const [loading, setLoading] = React.useState(false);
   const [cashError, setCashError] = React.useState(null);
   const [darkMode, setDarkMode] = React.useState(false);
+  const [holdings, setHoldings] = React.useState(getHoldingsWithValue(window.demoPortfolio));
 
   React.useEffect(() => {
     document.body.classList.toggle('dark', darkMode);
@@ -64,6 +72,25 @@ function PredictDemo() {
   return (
     <div className="container">
       <h1>SmartPortfolio React Demo (with Firebase)</h1>
+      <table className="transactions">
+        <thead>
+          <tr><th>Ticker</th><th>%</th><th>Value (DDK)</th></tr>
+        </thead>
+        <tbody>
+          {holdings.map((h, i) => (
+            <tr key={i}>
+              <td>{h.ticker}</td>
+              <td>{h.weight}</td>
+              <td>{h.value.toFixed(2)}</td>
+            </tr>
+          ))}
+          <tr>
+            <td>Cash</td>
+            <td>{(100 - window.demoPortfolio.holdings.reduce((a, b) => a + b.weight, 0)).toFixed(2)}</td>
+            <td>{(window.demoPortfolio.invested * (100 - window.demoPortfolio.holdings.reduce((a, b) => a + b.weight, 0)) / 100).toFixed(2)}</td>
+          </tr>
+        </tbody>
+      </table>
       <div className="controls">
         <label htmlFor="risk">{t.risk}:
           <select id="risk" value={risk} onChange={e => setRisk(e.target.value)}>

--- a/docs/demoPortfolio.js
+++ b/docs/demoPortfolio.js
@@ -1,0 +1,20 @@
+window.demoPortfolio = {
+  invested: 1500000,
+  holdings: [
+    { ticker: 'AMZN', weight: 7 },
+    { ticker: 'AXP', weight: 7 },
+    { ticker: 'C', weight: 5.25 },
+    { ticker: 'GE', weight: 6 },
+    { ticker: 'GOOG', weight: 7.7 },
+    { ticker: 'GS', weight: 5 },
+    { ticker: 'IAG.L', weight: 6.4 },
+    { ticker: 'JPM', weight: 5.42 },
+    { ticker: 'META', weight: 5.92 },
+    { ticker: 'MSFT', weight: 7.29 },
+    { ticker: 'NFLX', weight: 9.25 },
+    { ticker: 'NVDA', weight: 3.09 },
+    { ticker: 'PLTR', weight: 5.18 },
+    { ticker: 'RR.L', weight: 6.28 },
+    { ticker: 'SNOW', weight: 6.88 },
+  ]
+};

--- a/docs/index.html
+++ b/docs/index.html
@@ -35,6 +35,7 @@
   <div id="root"></div>
   <script src="firebase.js"></script>
   <script src="locales.js"></script>
+  <script src="demoPortfolio.js"></script>
   <script type="text/babel" src="app.jsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add demoPortfolio.js with provided stock weights
- display portfolio table in app.jsx
- load demoPortfolio script in index

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68886cca26a4832d8aa8090fe7d5f184