### PR TITLE
Improve mobile usability of React demo

### DIFF
--- a/docs/app.jsx
+++ b/docs/app.jsx
@@ -27,19 +27,43 @@ function dummyPredict(input, lang) {
   });
 }
 
+function Help({ text }) {
+  const [show, setShow] = React.useState(false);
+  return (
+    <span className="help" onClick={() => setShow(!show)}>
+      ?{show && <span className="helptext">{text}</span>}
+    </span>
+  );
+}
+
+const riskLevels = ['low', 'medium', 'high'];
+
 function PredictDemo() {
-  const [risk, setRisk] = React.useState('medium');
-  const [cash, setCash] = React.useState(10);
-  const [lang, setLang] = React.useState('en');
+  const [risk, setRisk] = React.useState(() => localStorage.getItem('risk') || 'medium');
+  const [cash, setCash] = React.useState(() => Number(localStorage.getItem('cash') || 10));
+  const [lang, setLang] = React.useState(() => localStorage.getItem('lang') || 'en');
   const [result, setResult] = React.useState(null);
   const [loading, setLoading] = React.useState(false);
   const [cashError, setCashError] = React.useState(null);
-  const [darkMode, setDarkMode] = React.useState(false);
+  const [darkMode, setDarkMode] = React.useState(() => localStorage.getItem('darkMode') === 'true');
   const [holdings, setHoldings] = React.useState(getHoldingsWithValue(window.demoPortfolio));
 
   React.useEffect(() => {
     document.body.classList.toggle('dark', darkMode);
+    localStorage.setItem('darkMode', darkMode);
   }, [darkMode]);
+
+  React.useEffect(() => {
+    localStorage.setItem('risk', risk);
+  }, [risk]);
+
+  React.useEffect(() => {
+    localStorage.setItem('cash', cash);
+  }, [cash]);
+
+  React.useEffect(() => {
+    localStorage.setItem('lang', lang);
+  }, [lang]);
 
   const t = window.locales[lang].labels;
 
@@ -93,16 +117,22 @@ function PredictDemo() {
       </table>
       <div className="controls">
         <label htmlFor="risk">{t.risk}:
-          <select id="risk" value={risk} onChange={e => setRisk(e.target.value)}>
-            <option value="low">low</option>
-            <option value="medium">medium</option>
-            <option value="high">high</option>
-          </select>
-          <span className="help" title="Select your overall risk appetite" aria-label="risk help">?</span>
+          <input
+            id="risk"
+            type="range"
+            min="0"
+            max="2"
+            step="1"
+            value={riskLevels.indexOf(risk)}
+            onChange={e => setRisk(riskLevels[e.target.value])}
+          />
+          <span className="range-value">{risk}</span>
+          <Help text={t.riskHelp} />
         </label>
         <label htmlFor="cash">{t.cash}:
-          <input id="cash" type="number" min="0" max="100" value={cash} onChange={handleCashChange} />
-          <span className="help" title="Percentage of portfolio kept as cash (0-100)" aria-label="cash help">?</span>
+          <input id="cash" type="range" min="0" max="100" value={cash} onChange={handleCashChange} />
+          <span className="range-value">{cash}%</span>
+          <Help text={t.cashHelp} />
         </label>
         {cashError && <div className="error">{cashError}</div>}
         <label htmlFor="lang">{t.lang}:

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SmartPortfolio React Demo</title>
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
@@ -11,12 +12,16 @@
     body { font-family: sans-serif; padding: 2em; transition: background 0.3s, color 0.3s; }
     label { margin-right: 1em; }
     .controls { display: flex; flex-wrap: wrap; gap: 1em; align-items: center; }
-    .help { margin-left: 0.3em; cursor: help; border-bottom: 1px dotted; }
+    .controls input[type="range"] { width: 100%; }
+    .controls input, .controls select, .controls button { padding: 0.4em; }
+    .range-value { margin-left: 0.5em; min-width: 2em; display: inline-block; text-align: center; }
+    .help { margin-left: 0.3em; cursor: pointer; border-bottom: 1px dotted; position: relative; }
+    .helptext { position: absolute; top: 1.5em; left: 0; background: #fff; color: #000; padding: 0.5em; border: 1px solid #ccc; z-index: 10; width: 200px; }
     .error { color: red; font-size: 0.9em; }
     .spinner { border: 3px solid #f3f3f3; border-top: 3px solid #555; border-radius: 50%; width: 16px; height: 16px; display: inline-block; animation: spin 1s linear infinite; margin-right: 0.5em; }
     @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
     table.transactions { border-collapse: collapse; width: 100%; margin-top: 0.5em; }
-    table.transactions th, table.transactions td { border: 1px solid #ccc; padding: 0.4em; text-align: left; }
+    table.transactions th, table.transactions td { border: 1px solid #ccc; padding: 0.6em; text-align: left; }
     table.transactions tr.buy { color: green; }
     table.transactions tr.sell { color: red; }
     .score-bar { background: #eee; width: 100%; height: 1em; margin-bottom: 0.5em; }
@@ -27,7 +32,9 @@
     body.dark table.transactions th, body.dark table.transactions td { border-color: #555; }
     @media (max-width: 600px) {
       .controls { flex-direction: column; align-items: stretch; }
-      .controls label, .controls button { width: 100%; }
+      .controls label, .controls button { width: 100%; font-size: 1.1em; }
+      table.transactions { display: block; overflow-x: auto; }
+      table.transactions th, table.transactions td { white-space: nowrap; }
     }
   </style>
 </head>

--- a/docs/locales.js
+++ b/docs/locales.js
@@ -10,7 +10,9 @@ window.locales = {
       darkMode: 'Dark Mode',
       cost: 'Cost',
       actions: { buy: 'Buy', sell: 'Sell' },
-      cashError: 'Cash percentage must be between 0 and 100'
+      cashError: 'Cash percentage must be between 0 and 100',
+      riskHelp: 'Select your overall risk appetite',
+      cashHelp: 'Percentage of portfolio kept as cash (0-100)'
     },
     explanationTechTooHigh: 'Your exposure to tech is too high'
   },
@@ -25,7 +27,9 @@ window.locales = {
       darkMode: 'M\u00f8rk tilstand',
       cost: 'Omkostning',
       actions: { buy: 'K\u00f8b', sell: 'S\u00e6lg' },
-      cashError: 'Kontant procent skal v\u00e6re mellem 0 og 100'
+      cashError: 'Kontant procent skal v\u00e6re mellem 0 og 100',
+      riskHelp: 'Vælg din overordnede risikovillighed',
+      cashHelp: 'Andel af porteføljen der holdes som kontant (0-100)'
     },
     explanationTechTooHigh: 'Din eksponering mod tech er for h\u00f8j'
   }


### PR DESCRIPTION
## Summary
- add viewport tag and responsive styles
- implement slider controls and inline help
- persist user preferences in localStorage

## Testing
- `python3 -m py_compile smartportfolio_cli.py`
- `python3 -m py_compile $(git ls-files '*.py' | tr '\n' ' ')`

------
https://chatgpt.com/codex/tasks/task_e_68886d50dfb0832da3617137b12ed009