### PR TITLE
Expand React demo with additional pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,7 @@
   <title>SmartPortfolio React Demo</title>
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
   <style>
@@ -21,9 +22,16 @@
     table.transactions tr.sell { color: red; }
     .score-bar { background: #eee; width: 100%; height: 1em; margin-bottom: 0.5em; }
     .score-bar .score { background: #4caf50; height: 100%; }
+    nav { margin-bottom: 1em; }
+    nav a { margin-right: 1em; color: inherit; text-decoration: none; }
+    nav a.active { font-weight: bold; }
+    ul.history { list-style: none; padding: 0; }
+    ul.history li { display: flex; align-items: center; margin: 0.25em 0; }
+    ul.history .bar { height: 1em; background: #4caf50; margin-right: 0.5em; }
     body.dark { background: #121212; color: #eee; }
     body.dark .score-bar { background: #333; }
     body.dark .score-bar .score { background: #81c784; }
+    body.dark ul.history .bar { background: #81c784; }
     body.dark table.transactions th, body.dark table.transactions td { border-color: #555; }
     @media (max-width: 600px) {
       .controls { flex-direction: column; align-items: stretch; }

--- a/docs/locales.js
+++ b/docs/locales.js
@@ -10,7 +10,15 @@ window.locales = {
       darkMode: 'Dark Mode',
       cost: 'Cost',
       actions: { buy: 'Buy', sell: 'Sell' },
-      cashError: 'Cash percentage must be between 0 and 100'
+      cashError: 'Cash percentage must be between 0 and 100',
+      nav: {
+        dashboard: 'Dashboard',
+        predict: 'Predict',
+        history: 'History',
+        settings: 'Settings'
+      },
+      notify: 'Notification frequency',
+      save: 'Save'
     },
     explanationTechTooHigh: 'Your exposure to tech is too high'
   },
@@ -25,7 +33,15 @@ window.locales = {
       darkMode: 'M\u00f8rk tilstand',
       cost: 'Omkostning',
       actions: { buy: 'K\u00f8b', sell: 'S\u00e6lg' },
-      cashError: 'Kontant procent skal v\u00e6re mellem 0 og 100'
+      cashError: 'Kontant procent skal v\u00e6re mellem 0 og 100',
+      nav: {
+        dashboard: 'Oversigt',
+        predict: 'Beregn',
+        history: 'Historik',
+        settings: 'Indstillinger'
+      },
+      notify: 'Notifikationsfrekvens',
+      save: 'Gem'
     },
     explanationTechTooHigh: 'Din eksponering mod tech er for h\u00f8j'
   }


### PR DESCRIPTION
## Summary
- enhance `docs/index.html` with router script and new styles for navigation and history
- extend `docs/locales.js` with labels for navigation and settings
- rewrite `docs/app.jsx` to include React Router and new Dashboard, History, and Settings pages

## Testing
- `npx babel docs/app.jsx --out-file /tmp/out.js` *(fails: 403 Forbidden - GET https://registry.npmjs.org/babel)*

------
https://chatgpt.com/codex/tasks/task_e_68886e494adc832da81f306c0ceb1428