### PR TITLE
Add client error boundary

### DIFF
--- a/docs/app.jsx
+++ b/docs/app.jsx
@@ -32,6 +32,30 @@ const demoHistory = [
   1018000, 1032000, 1040000, 1035000, 1050000
 ];
 
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('ErrorBoundary caught:', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      const en = window.locales.en.errorBoundaryMessage;
+      const da = window.locales.da.errorBoundaryMessage;
+      return <div className="error">{en} / {da}</div>;
+    }
+    return this.props.children;
+  }
+}
+
 function DashboardPage({ lang }) {
   const holdings = React.useMemo(
     () => getHoldingsWithValue(window.demoPortfolio),
@@ -250,5 +274,9 @@ function App() {
 }
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<App />);
+root.render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
+);
 

--- a/docs/locales.js
+++ b/docs/locales.js
@@ -20,7 +20,8 @@ window.locales = {
       notify: 'Notification frequency',
       save: 'Save'
     },
-    explanationTechTooHigh: 'Your exposure to tech is too high'
+    explanationTechTooHigh: 'Your exposure to tech is too high',
+    errorBoundaryMessage: 'Something went wrong. Please reload the page.'
   },
   da: {
     labels: {
@@ -43,6 +44,7 @@ window.locales = {
       notify: 'Notifikationsfrekvens',
       save: 'Gem'
     },
-    explanationTechTooHigh: 'Din eksponering mod tech er for h\u00f8j'
+    explanationTechTooHigh: 'Din eksponering mod tech er for h\u00f8j',
+    errorBoundaryMessage: 'Noget gik galt. Genindl\u00e6s venligst siden.'
   }
 };


### PR DESCRIPTION
## Summary
- show errors in both English and Danish
- wrap the app with a new ErrorBoundary component

## Testing
- `python3 -m http.server 8000` *(served demo locally)*

------
https://chatgpt.com/codex/tasks/task_e_6888829da90c832dbbf71b5a6c315d50