### PR TITLE
Implement larger button styling

### DIFF
--- a/docs/consoleCapture.js
+++ b/docs/consoleCapture.js
@@ -11,7 +11,7 @@
     background: 'rgba(0,0,0,0.8)',
     color: 'white',
     fontFamily: 'monospace',
-    fontSize: '12px',
+    fontSize: '16px',
     zIndex: '10000',
     padding: '0.5em',
     display: 'none'
@@ -25,7 +25,9 @@
     color: 'white',
     border: 'none',
     cursor: 'pointer',
-    marginLeft: '0.5em'
+    marginLeft: '0.5em',
+    fontSize: '1em',
+    padding: '0.5em 1em'
   });
 
   const copyBtn = document.createElement('button');
@@ -36,7 +38,9 @@
     color: 'white',
     border: 'none',
     cursor: 'pointer',
-    marginLeft: '0.5em'
+    marginLeft: '0.5em',
+    fontSize: '1em',
+    padding: '0.5em 1em'
   });
 
   copyBtn.onclick = function() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,7 @@
   <style>
     body { font-family: sans-serif; padding: 2em; transition: background 0.3s, color 0.3s; }
     label { margin-right: 1em; }
+    button { font-size: 1.5em; padding: 0.8em 1.6em; }
     .controls { display: flex; flex-wrap: wrap; gap: 1em; align-items: center; }
     .help { margin-left: 0.3em; cursor: help; border-bottom: 1px dotted; }
     .error { color: red; font-size: 0.9em; }
@@ -36,7 +37,8 @@
     body.dark table.transactions th, body.dark table.transactions td { border-color: #555; }
     @media (max-width: 600px) {
       .controls { flex-direction: column; align-items: stretch; }
-      .controls label, .controls button { width: 100%; }
+      .controls label { width: 100%; }
+      button { width: 100%; }
       nav a { display: block; margin: 0.25em 0; }
     }
   </style>


### PR DESCRIPTION
## Summary
- enlarge global button sizing for better PWA usability
- scale console overlay buttons as well

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6888962d75a4832d822a155be4b90874