### PR TITLE
Add responsive navigation menu

### DIFF
--- a/docs/app.jsx
+++ b/docs/app.jsx
@@ -232,6 +232,7 @@ function App() {
   const [lang, setLang] = React.useState('en');
   const [darkMode, setDarkMode] = React.useState(false);
   const [page, setPage] = React.useState('dashboard');
+  const [menuOpen, setMenuOpen] = React.useState(false);
 
   React.useEffect(() => {
     if (window.loadVision) {
@@ -272,6 +273,7 @@ function App() {
       onClick={e => {
         e.preventDefault();
         setPage(key);
+        setMenuOpen(false);
       }}
     >
       {label}
@@ -280,21 +282,30 @@ function App() {
 
   return (
     <div>
-      <nav>
-        {navLink('dashboard', t.nav.dashboard)}
-        {navLink('predict', t.nav.predict)}
-        {navLink('history', t.nav.history)}
-        {navLink('vision', t.nav.vision)}
-        {navLink('settings', t.nav.settings)}
-        <label htmlFor="langSelect">{t.lang}:
-          <select id="langSelect" value={lang} onChange={e => setLang(e.target.value)}>
-            <option value="en">English</option>
-            <option value="da">Dansk</option>
-          </select>
-        </label>
-        <label>
-          <input type="checkbox" checked={darkMode} onChange={e => setDarkMode(e.target.checked)} /> {t.darkMode}
-        </label>
+      <nav className={menuOpen ? 'open' : ''}>
+        <button
+          className="mobile-toggle"
+          onClick={() => setMenuOpen(!menuOpen)}
+          aria-label="Toggle menu"
+        >
+          ☰
+        </button>
+        <div className="nav-links">
+          {navLink('dashboard', t.nav.dashboard)}
+          {navLink('predict', t.nav.predict)}
+          {navLink('history', t.nav.history)}
+          {navLink('vision', t.nav.vision)}
+          {navLink('settings', t.nav.settings)}
+          <label htmlFor="langSelect">{t.lang}:
+            <select id="langSelect" value={lang} onChange={e => setLang(e.target.value)}>
+              <option value="en">English</option>
+              <option value="da">Dansk</option>
+            </select>
+          </label>
+          <label>
+            <input type="checkbox" checked={darkMode} onChange={e => setDarkMode(e.target.checked)} /> {t.darkMode}
+          </label>
+        </div>
       </nav>
       {renderPage()}
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,9 +24,10 @@
     table.transactions tr.sell { color: red; }
     .score-bar { background: #eee; width: 100%; height: 1em; margin-bottom: 0.5em; }
     .score-bar .score { background: #4caf50; height: 100%; }
-    nav { margin-bottom: 1em; }
-    nav a { margin-right: 1em; color: inherit; text-decoration: none; }
-    nav a.active { font-weight: bold; }
+    nav { margin-bottom: 1em; display: flex; align-items: center; flex-wrap: wrap; }
+    nav .mobile-toggle { display: none; font-size: 1.5em; background: none; border: none; margin-right: 0.5em; cursor: pointer; }
+    nav .nav-links a { margin-right: 1em; color: inherit; text-decoration: none; }
+    nav .nav-links a.active { font-weight: bold; }
     ul.history { list-style: none; padding: 0; }
     ul.history li { display: flex; align-items: center; margin: 0.25em 0; }
     ul.history .bar { height: 1em; background: #4caf50; margin-right: 0.5em; }
@@ -38,7 +39,10 @@
     @media (max-width: 600px) {
       .controls { flex-direction: column; align-items: stretch; }
       .controls label { width: 100%; }
-      nav a { display: block; margin: 0.25em 0; }
+      nav .mobile-toggle { display: block; }
+      nav .nav-links { display: none; width: 100%; }
+      nav.open .nav-links { display: block; }
+      nav .nav-links a { display: block; margin: 0.25em 0; }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- add mobile toggle button and responsive CSS
- wrap nav links in a container and close menu on navigation

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68889acd681c832d87068ab3c7147ba9