### PR TITLE
Move index.html to project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A simple user interface could include:
 
 ## Web Demo
 
-The `docs/` folder now contains a lightweight React web demo that can be served via GitHub Pages. It handles Firebase initialisation directly in the browser and uses [Tailwind CSS](https://tailwindcss.com/) for responsive styling on both mobile and desktop. If you replace it with a full React app, build it locally (for example with `npm run build`) and copy the static files into `docs/`.
+The project root now hosts `index.html` so it can be served directly on GitHub Pages. The supporting scripts still live inside the `docs/` folder. It handles Firebase initialisation directly in the browser and uses [Tailwind CSS](https://tailwindcss.com/) for responsive styling on both mobile and desktop. If you replace it with a full React app, build it locally (for example with `npm run build`) and copy the static files into `docs/`.
 
 The old Flutter demo has been removed. If no build is present, the page shows a simple placeholder message. A future backend will also be written in JavaScript.
 

--- a/index.html
+++ b/index.html
@@ -48,13 +48,13 @@
 </head>
 <body>
   <div id="root"></div>
-  <script src="consoleCapture.js"></script>
-  <script src="firebase.js"></script>
-  <script src="locales.js"></script>
-  <script src="demoPortfolio.js"></script>
-  <script src="marketData.js"></script>
-  <script src="vision.js"></script>
-  <script src="clientPredict.js"></script>
-  <script type="text/babel" src="app.jsx"></script>
+  <script src="docs/consoleCapture.js"></script>
+  <script src="docs/firebase.js"></script>
+  <script src="docs/locales.js"></script>
+  <script src="docs/demoPortfolio.js"></script>
+  <script src="docs/marketData.js"></script>
+  <script src="docs/vision.js"></script>
+  <script src="docs/clientPredict.js"></script>
+  <script type="text/babel" src="docs/app.jsx"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move web demo entry point to repository root for easier GitHub Pages hosting
- update paths in `index.html`
- clarify instructions in README about new location

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888a8d216e8832db999a879a424a68b