### PR TITLE
Fix Firestore connectivity

### DIFF
--- a/docs/firebase.js
+++ b/docs/firebase.js
@@ -13,5 +13,8 @@ const firebaseConfig = {
 };
 
 firebase.initializeApp(firebaseConfig);
-window.db = firebase.firestore();
+// Enable fallback to long-polling in case WebSockets are blocked
+const firestore = firebase.firestore();
+firestore.settings({ experimentalAutoDetectLongPolling: true });
+window.db = firestore;
 console.log("Firebase initialized");


### PR DESCRIPTION
## Summary
- enable auto long-polling fallback in Firebase initialization

## Testing
- `node smartportfolio_cli.js`

------
https://chatgpt.com/codex/tasks/task_e_6888a6681480832d9e3468852450721e