### PR TITLE
Update docs for React app production

### DIFF
--- a/.github/workflows/react_app.yml
+++ b/.github/workflows/react_app.yml
@@ -1,10 +1,10 @@
-name: Deploy React Web Demo
+name: Deploy React Web App
 
 on:
   push:
     paths:
       - 'src/**'
-      - '.github/workflows/flutter_web_demo.yml'
+      - '.github/workflows/react_app.yml'
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ SmartPortfolio is intended to:
 
 This project is currently in the planning phase. More documentation and implementation details will follow as development progresses.
 
+The React application in the repository root is now the production front-end served via GitHub Pages.
+
 ## Command Line Demo
 
 The repository now includes a small CLI demonstrating the five GUI concepts:
@@ -42,9 +44,9 @@ A simple user interface could include:
 5. **Settings** – personal preferences for risk level, sectors, and notification frequency.
 
 
-## Web Demo
+## React App
 
-The project root now hosts `index.html` so it can be served directly on GitHub Pages. The supporting scripts still live inside the `src/` folder. It handles Firebase initialisation directly in the browser and uses [Tailwind CSS](https://tailwindcss.com/) for responsive styling on both mobile and desktop. If you replace it with a full React app, build it locally (for example with `npm run build`) and copy the static files into `src/`.
+The project root hosts `index.html` which contains the production React application served from GitHub Pages. The supporting scripts live inside the `src/` folder. Build the app locally (for example with `npm run build`) and copy the static files into `src/` when updating the site.
 
-The old Flutter demo has been removed. If no build is present, the page shows a simple placeholder message. A future backend will also be written in JavaScript.
+The old Flutter demo has been removed. If no build is present, the page shows a simple placeholder message. The backend will also be written in JavaScript.
 

--- a/docs/PREDICT.md
+++ b/docs/PREDICT.md
@@ -82,8 +82,8 @@ The predict function forms the core of SmartPortfolio. It evaluates the current 
 ### Functionality and logic
 The predict function combines a scoring model and rule set to ensure diversification, cash buffer and maximum exposure. Each stock is rated by key figures, performance and fit with the user’s strategy.
 
-### Client-side demo
-For the React demo a lightweight JavaScript version called `clientPredict` is used. It offers three suggested portfolios based on risk level, cash percentage and a chosen segment bias. Each suggestion includes an estimated return so users can compare before selecting.
+### Client-side app
+The React app uses a lightweight JavaScript version called `clientPredict`. It offers three suggested portfolios based on risk level, cash percentage and a chosen segment bias. Each suggestion includes an estimated return so users can compare before selecting.
 
 ### Example call
 ```javascript

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>SmartPortfolio React Demo</title>
+  <title>SmartPortfolio</title>
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,7 +1,7 @@
-// Minimal Firebase setup for SmartPortfolio React demo
+// Minimal Firebase setup for the SmartPortfolio React app
 // Replace with real project credentials when deploying.
 
-// Firebase configuration for the public demo project
+// Firebase configuration for the public development project
 const firebaseConfig = {
   apiKey: "AIzaSyAwb70Myug06CMrwysQ-VNKIEoYs2D79sk",
   authDomain: "stocks-d68d0.firebaseapp.com",


### PR DESCRIPTION
## Summary
- clarify that React app in repo root is now the production frontend
- update docs and workflow naming accordingly
- remove "React Demo" wording in index and Firebase setup

## Testing
- `node smartportfolio_cli.js <<'EOF'
6
EOF`
- `node --check src/clientPredict.js`
- `node --check src/firebase.js`
- `node --check smartportfolio_cli.js`


------
https://chatgpt.com/codex/tasks/task_e_6888d3652b28832d8140bbed537ff092