### PR TITLE
Add Firebase initialization and ticker update controls

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -207,6 +207,18 @@ function SettingsPage({ lang }) {
       >
         {t.save}
       </button>
+      <button
+        className="bg-blue-600 text-white text-xl px-6 py-3 rounded mt-2 w-full sm:w-auto"
+        onClick={() => window.initFirebase && window.initFirebase()}
+      >
+        {t.initFirebase}
+      </button>
+      <button
+        className="bg-blue-600 text-white text-xl px-6 py-3 rounded mt-2 w-full sm:w-auto"
+        onClick={() => window.loadMarketData && window.loadMarketData()}
+      >
+        {t.updateTickers}
+      </button>
     </div>
   );
 }
@@ -218,6 +230,9 @@ function App() {
   const [menuOpen, setMenuOpen] = React.useState(false);
 
   React.useEffect(() => {
+    if (window.initFirebase) {
+      window.initFirebase();
+    }
     if (window.loadVision) {
       window.loadVision();
     }

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -12,9 +12,17 @@ const firebaseConfig = {
   measurementId: "G-7YBHJLY6Y9"
 };
 
-firebase.initializeApp(firebaseConfig);
-// Enable fallback to long-polling in case WebSockets are blocked
-const firestore = firebase.firestore();
-firestore.settings({ experimentalAutoDetectLongPolling: true });
-window.db = firestore;
-console.log("Firebase initialized");
+function initFirebase() {
+  if (window.db) {
+    console.log("Firebase already initialized");
+    return;
+  }
+  firebase.initializeApp(firebaseConfig);
+  // Enable fallback to long-polling in case WebSockets are blocked
+  const firestore = firebase.firestore();
+  firestore.settings({ experimentalAutoDetectLongPolling: true });
+  window.db = firestore;
+  console.log("Firebase initialized");
+}
+
+window.initFirebase = initFirebase;

--- a/src/locales.js
+++ b/src/locales.js
@@ -24,7 +24,9 @@ window.locales = {
         settings: 'Settings'
       },
       notify: 'Notification frequency',
-      save: 'Save'
+      save: 'Save',
+      initFirebase: 'Init Firebase',
+      updateTickers: 'Update tickers'
     },
     biasExplanation: {
       none: 'No specific segment focus',
@@ -64,7 +66,9 @@ window.locales = {
         settings: 'Indstillinger'
       },
       notify: 'Notifikationsfrekvens',
-      save: 'Gem'
+      save: 'Gem',
+      initFirebase: 'Initialis\u00e9r Firebase',
+      updateTickers: 'Opdater tickers'
     },
     biasExplanation: {
       none: 'Ingen specifik segmentfokus',


### PR DESCRIPTION
## Summary
- expose a new `initFirebase` function
- call Firebase initialization on app start
- add buttons in Settings to initialize Firebase and refresh market quotes
- translate the new buttons in both English and Danish locales

## Testing
- `node smartportfolio_cli.js | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6888d680437c832db4c7495a4a605851