### PR TITLE
Add text to settings buttons

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -204,18 +204,21 @@ function SettingsPage({ lang }) {
       <button
         className="bg-blue-600 text-white text-xl px-6 py-3 rounded mt-2 w-full sm:w-auto"
         onClick={() => alert('Saved')}
+        title={t.save}
       >
         {t.save}
       </button>
       <button
         className="bg-blue-600 text-white text-xl px-6 py-3 rounded mt-2 w-full sm:w-auto"
         onClick={() => window.initFirebase && window.initFirebase()}
+        title={t.initFirebase}
       >
         {t.initFirebase}
       </button>
       <button
         className="bg-blue-600 text-white text-xl px-6 py-3 rounded mt-2 w-full sm:w-auto"
         onClick={() => window.loadMarketData && window.loadMarketData()}
+        title={t.updateTickers}
       >
         {t.updateTickers}
       </button>

--- a/src/locales.js
+++ b/src/locales.js
@@ -24,8 +24,8 @@ window.locales = {
         settings: 'Settings'
       },
       notify: 'Notification frequency',
-      save: 'Save',
-      initFirebase: 'Init Firebase',
+      save: 'Save settings',
+      initFirebase: 'Initialize Firebase',
       updateTickers: 'Update tickers'
     },
     biasExplanation: {
@@ -66,7 +66,7 @@ window.locales = {
         settings: 'Indstillinger'
       },
       notify: 'Notifikationsfrekvens',
-      save: 'Gem',
+      save: 'Gem indstillinger',
       initFirebase: 'Initialis\u00e9r Firebase',
       updateTickers: 'Opdater tickers'
     },


### PR DESCRIPTION
## Summary
- add title attributes to buttons on the settings page
- update locales with more descriptive button labels

## Testing
- `node smartportfolio_cli.js <<'EOF'
6
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6888d8b53ba4832d9ded696b83436953