### PR TITLE
Fix Firebase setup using modular SDK

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,7 @@
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore-compat.js"></script>
+  <!-- Firebase modular SDK imports are handled inside our modules -->
   <style>
     body {
       font-family: sans-serif;
@@ -69,11 +68,11 @@
 <body>
   <div id="root"></div>
   <script src="src/consoleCapture.js"></script>
-  <script src="src/firebase.js"></script>
+  <script type="module" src="src/firebase.js"></script>
   <script src="src/locales.js"></script>
   <script src="src/demoPortfolio.js"></script>
-  <script src="src/marketData.js"></script>
-  <script src="src/vision.js"></script>
+  <script type="module" src="src/marketData.js"></script>
+  <script type="module" src="src/vision.js"></script>
   <script src="src/clientPredict.js"></script>
   <script type="text/babel" src="src/app.jsx"></script>
 </body>

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,5 +1,9 @@
 // Minimal Firebase setup for the SmartPortfolio React app
-// Replace with real project credentials when deploying.
+// Using the modular Firebase SDK loaded from the CDN.
+
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/9.22.1/firebase-app.js';
+import { getAnalytics } from 'https://www.gstatic.com/firebasejs/9.22.1/firebase-analytics.js';
+import { initializeFirestore } from 'https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore.js';
 
 // Firebase configuration for the public development project
 const firebaseConfig = {
@@ -14,15 +18,20 @@ const firebaseConfig = {
 
 function initFirebase() {
   if (window.db) {
-    console.log("Firebase already initialized");
+    console.log('Firebase already initialized');
     return;
   }
-  firebase.initializeApp(firebaseConfig);
+  const app = initializeApp(firebaseConfig);
+  try {
+    getAnalytics(app);
+  } catch (err) {
+    // Analytics is optional and will fail on unsupported environments
+    console.warn('Analytics init failed', err);
+  }
   // Enable fallback to long-polling in case WebSockets are blocked
-  const firestore = firebase.firestore();
-  firestore.settings({ experimentalAutoDetectLongPolling: true });
-  window.db = firestore;
-  console.log("Firebase initialized");
+  const db = initializeFirestore(app, { experimentalAutoDetectLongPolling: true });
+  window.db = db;
+  console.log('Firebase initialized');
 }
 
 window.initFirebase = initFirebase;

--- a/src/marketData.js
+++ b/src/marketData.js
@@ -1,15 +1,17 @@
 // Load market quotes from Yahoo Finance and cache in Firestore
+import { collection, doc, getDoc, setDoc, Timestamp } from 'https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore.js';
+
 async function loadMarketData() {
   if (!window.db) {
     console.error('Firestore not initialized');
     return;
   }
-  const docRef = window.db.collection('marketData').doc('latest');
+  const docRef = doc(collection(window.db, 'marketData'), 'latest');
   try {
-    const doc = await docRef.get();
+    const snapshot = await getDoc(docRef);
     let shouldUpdate = true;
-    if (doc.exists) {
-      const data = doc.data();
+    if (snapshot.exists()) {
+      const data = snapshot.data();
       if (data.updated && Date.now() - data.updated.toMillis() < 86400000) {
         shouldUpdate = false;
         window.marketData = data.quotes;
@@ -30,7 +32,7 @@ async function loadMarketData() {
           };
         });
       }
-      await docRef.set({ quotes, updated: firebase.firestore.Timestamp.now() });
+      await setDoc(docRef, { quotes, updated: Timestamp.now() });
       window.marketData = quotes;
     }
   } catch (err) {

--- a/src/vision.js
+++ b/src/vision.js
@@ -1,15 +1,17 @@
 // Load vision document from GitHub and cache in Firestore
+import { collection, doc, getDoc, setDoc, Timestamp } from 'https://www.gstatic.com/firebasejs/9.22.1/firebase-firestore.js';
+
 async function loadVision() {
   if (!window.db) {
     console.error('Firestore not initialized');
     return;
   }
-  const docRef = window.db.collection('vision').doc('latest');
+  const docRef = doc(collection(window.db, 'vision'), 'latest');
   try {
-    const doc = await docRef.get();
+    const snapshot = await getDoc(docRef);
     let shouldUpdate = true;
-    if (doc.exists) {
-      const data = doc.data();
+    if (snapshot.exists()) {
+      const data = snapshot.data();
       if (data.updated && Date.now() - data.updated.toMillis() < 86400000) {
         shouldUpdate = false;
         window.visionText = data.text;
@@ -18,7 +20,7 @@ async function loadVision() {
     if (shouldUpdate) {
       const resp = await fetch('https://raw.githubusercontent.com/nyhave/Stocks/main/VISION.md');
       const text = await resp.text();
-      await docRef.set({ text, updated: firebase.firestore.Timestamp.now() });
+      await setDoc(docRef, { text, updated: Timestamp.now() });
       window.visionText = text;
     }
   } catch (err) {


### PR DESCRIPTION
## Summary
- use Firebase v9 modules instead of compat scripts
- adjust Firestore access in `marketData.js` and `vision.js`
- load scripts as ES modules in `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6888dec8ee90832d8ed94990dddbb047