### PR TITLE
Add log message after first Firestore write

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -44,14 +44,15 @@ async function checkFirestoreConnection(db) {
   const testRef = doc(collection(db, 'connectionTest'), 'ping');
   try {
     await setDoc(testRef, { time: Date.now() });
+    console.log('First write succeeded / Første skrivning lykkedes');
     const snap = await getDoc(testRef);
     if (snap.exists()) {
-      console.log('Connection test succeeded');
+      console.log('Connection test succeeded / Forbindelsestest lykkedes');
     } else {
-      console.warn('Connection test failed');
+      console.warn('Connection test failed / Forbindelsestest fejlede');
     }
   } catch (err) {
-    console.error('Connection test failed', err);
+    console.error('First write failed / Første skrivning fejlede', err);
   }
 }
 


### PR DESCRIPTION
## Summary
- log success or failure after the first Firestore write in `checkFirestoreConnection`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68892611f634832d854ae4dd4e8c149d