### PR TITLE
Remove Danish language from UI

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -195,7 +195,6 @@ function SettingsPage({ lang, setLang, darkMode, setDarkMode }) {
           onChange={e => setLang(e.target.value)}
         >
           <option value="en">English</option>
-          <option value="da">Dansk</option>
         </select>
       </label>
       <label>

--- a/src/locales.js
+++ b/src/locales.js
@@ -41,48 +41,5 @@ window.locales = {
       aggressive: 'Aggressive'
     },
     explanationTechTooHigh: 'Your exposure to tech is too high'
-  },
-  da: {
-    labels: {
-      risk: 'Risiko',
-      cash: 'Kontant %',
-      bias: 'Segment bias',
-      lang: 'Sprog',
-      predict: 'Beregn',
-      predicting: 'Beregner...',
-      result: 'Resultat',
-      darkMode: 'M\u00f8rk tilstand',
-      cost: 'Omkostning',
-      price: 'Pris',
-      actions: { buy: 'K\u00f8b', sell: 'S\u00e6lg' },
-      cashError: 'Kontant procent skal v\u00e6re mellem 0 og 100',
-      select: 'V\u00e6lg',
-      show: 'Forklar',
-      improvement: 'Forbedring',
-      expectedReturn: 'Forventet afkast',
-      nav: {
-        dashboard: 'Oversigt',
-        predict: 'Beregn',
-        history: 'Historik',
-        settings: 'Indstillinger'
-      },
-      notify: 'Notifikationsfrekvens',
-      save: 'Gem indstillinger',
-      initFirebase: 'Initialis\u00e9r Firebase',
-      updateTickers: 'Opdater tickers',
-      loadData: 'Ops\u00e6t og hent markeddata'
-    },
-    biasExplanation: {
-      none: 'Ingen specifik segmentfokus',
-      tech: 'St\u00f8rre andel i tech-aktier',
-      finance: 'St\u00f8rre andel i finansaktier',
-      industrial: 'St\u00f8rre andel i industrisektoren'
-    },
-    portfolioNames: {
-      defensive: 'Defensiv',
-      balanced: 'Balanceret',
-      aggressive: 'Aggressiv'
-    },
-    explanationTechTooHigh: 'Din eksponering mod tech er for h\u00f8j'
   }
 };


### PR DESCRIPTION
## Summary
- drop Danish option in Settings
- remove Danish translations from `locales.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688926c8284c832d889b19acd177e5ac