### PR TITLE
Remove Danish overlay labels

### DIFF
--- a/src/consoleCapture.js
+++ b/src/consoleCapture.js
@@ -18,7 +18,7 @@
   });
 
   const dismissBtn = document.createElement('button');
-  dismissBtn.textContent = 'Dismiss / Luk';
+  dismissBtn.textContent = 'Dismiss';
   Object.assign(dismissBtn.style, {
     float: 'right',
     background: '#444',
@@ -29,7 +29,7 @@
   });
 
   const copyBtn = document.createElement('button');
-  copyBtn.textContent = 'Copy / Kopier';
+  copyBtn.textContent = 'Copy';
   Object.assign(copyBtn.style, {
     float: 'right',
     background: '#444',


### PR DESCRIPTION
## Summary
- remove Danish words from log overlay button labels

## Testing
- `grep -n "Dismiss" -n src/consoleCapture.js`


------
https://chatgpt.com/codex/tasks/task_e_68892a7b87e4832dab477fd84a06c09a