### PR TITLE
Add connection test and separate market data button

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -232,15 +232,34 @@ function SettingsPage({ lang, setLang, darkMode, setDarkMode }) {
           if (window.initFirebase) {
             window.initFirebase();
           }
+        }}
+        title={t.initFirebase}
+      >
+        {t.initFirebase}
+      </button>
+      <button
+        className="bg-blue-600 text-white text-xl px-6 py-3 rounded mt-2 w-full sm:w-auto"
+        onClick={() => {
+          if (window.testConnection) {
+            window.testConnection();
+          }
+        }}
+        title={t.testConnection}
+      >
+        {t.testConnection}
+      </button>
+      <button
+        className="bg-blue-600 text-white text-xl px-6 py-3 rounded mt-2 w-full sm:w-auto"
+        onClick={() => {
           if (window.loadMarketData) {
             window.loadMarketData().then(() => {
               if (window.updateHoldings) window.updateHoldings();
             });
           }
         }}
-        title={t.loadData}
+        title={t.readMarket}
       >
-        {t.loadData}
+        {t.readMarket}
       </button>
     </div>
   );

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -37,7 +37,6 @@ function initFirebase() {
   const db = initializeFirestore(app, { experimentalAutoDetectLongPolling: true });
   window.db = db;
   console.log('Firebase initialized');
-  checkFirestoreConnection(db);
 }
 
 async function checkFirestoreConnection(db) {
@@ -48,12 +47,31 @@ async function checkFirestoreConnection(db) {
     const snap = await getDoc(testRef);
     if (snap.exists()) {
       console.log('Connection test succeeded / Forbindelsestest lykkedes');
+      return true;
     } else {
       console.warn('Connection test failed / Forbindelsestest fejlede');
+      return false;
     }
   } catch (err) {
     console.error('First write failed / Første skrivning fejlede', err);
+    return false;
   }
 }
+
+async function testFirestoreConnection() {
+  if (!window.db) {
+    console.warn('Firestore not initialized');
+    alert('Firestore not initialized');
+    return;
+  }
+  const ok = await checkFirestoreConnection(window.db);
+  if (ok) {
+    alert('Connection test succeeded');
+  } else {
+    alert('Connection test failed');
+  }
+}
+
+window.testConnection = testFirestoreConnection;
 
 window.initFirebase = initFirebase;

--- a/src/locales.js
+++ b/src/locales.js
@@ -26,8 +26,9 @@ window.locales = {
       notify: 'Notification frequency',
       save: 'Save settings',
       initFirebase: 'Initialize Firebase',
-      updateTickers: 'Update tickers',
-      loadData: 'Setup and load market data'
+      testConnection: 'Test connection',
+      readMarket: 'Read market data',
+      updateTickers: 'Update tickers'
     },
     biasExplanation: {
       none: 'No specific segment focus',


### PR DESCRIPTION
## Summary
- provide a dedicated `testConnection` function in `firebase.js`
- break up setup actions in the settings page
- add separate buttons for Firebase init, connection test and reading market data
- update labels in locale file

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6889aa4eb25c832da1ae3276cc22f15d