### PR TITLE
Add verbose Firestore logging

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -25,11 +25,13 @@ const firebaseConfig = {
 
 function initFirebase() {
   console.log('initFirebase called');
+  console.log('Firebase config', firebaseConfig);
   if (window.db) {
     console.log('Firebase already initialized');
     return;
   }
   const app = initializeApp(firebaseConfig);
+  console.log('Firebase app created', app.name);
   try {
     getAnalytics(app);
   } catch (err) {
@@ -38,32 +40,41 @@ function initFirebase() {
   }
   // Enable fallback to long-polling in case WebSockets are blocked
   const db = initializeFirestore(app, { experimentalAutoDetectLongPolling: true });
+  console.log('Firestore initialized');
   window.db = db;
   console.log('Firebase initialized, window.db set');
 }
 
 async function checkFirestoreConnection(db) {
-  console.log('checkFirestoreConnection called');
+  console.log('checkFirestoreConnection called', db);
   const testRef = doc(collection(db, 'connectionTest'), 'ping');
+  console.log('Test reference', testRef.path);
   try {
+    console.log('Writing test ping');
     await setDoc(testRef, { time: Date.now() });
     console.log('First write succeeded / Første skrivning lykkedes');
+    console.log('Reading back test ping');
     const snap = await getDoc(testRef);
+    console.log('Snapshot exists', snap.exists());
     if (snap.exists()) {
       console.log('Connection test succeeded / Forbindelsestest lykkedes');
+      console.log('Returning true from checkFirestoreConnection');
       return true;
     } else {
       console.warn('Connection test failed / Forbindelsestest fejlede');
+      console.log('Returning false from checkFirestoreConnection');
       return false;
     }
   } catch (err) {
     console.error('First write failed / Første skrivning fejlede', err);
+    console.log('Returning false from checkFirestoreConnection');
     return false;
   }
 }
 
 async function testFirestoreConnection() {
   console.log('testFirestoreConnection called');
+  console.log('Current db instance', window.db);
   if (!window.db) {
     console.warn('Firestore not initialized');
     alert('Firestore not initialized');

--- a/src/marketData.js
+++ b/src/marketData.js
@@ -7,10 +7,13 @@ async function loadMarketData() {
     return;
   }
   const docRef = doc(collection(window.db, 'marketData'), 'latest');
+  console.log('Market data docRef', docRef.path);
   try {
+    console.log('Checking cached market data');
     const snapshot = await getDoc(docRef);
     let shouldUpdate = true;
     if (snapshot.exists()) {
+      console.log('Found cached data', snapshot.data());
       const data = snapshot.data();
       if (data.updated && Date.now() - data.updated.toMillis() < 86400000) {
         shouldUpdate = false;
@@ -19,10 +22,12 @@ async function loadMarketData() {
     }
     if (shouldUpdate) {
       const tickers = window.demoPortfolio.holdings.map(h => h.ticker).join(',');
+      console.log('Fetching quotes for', tickers);
       const resp = await fetch(
         `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${tickers}`
       );
       const json = await resp.json();
+      console.log('Quote response', json);
       const quotes = {};
       if (json && json.quoteResponse && json.quoteResponse.result) {
         json.quoteResponse.result.forEach(r => {
@@ -32,6 +37,7 @@ async function loadMarketData() {
           };
         });
       }
+      console.log('Saving quotes to Firestore');
       await setDoc(docRef, { quotes, updated: Timestamp.now() });
       window.marketData = quotes;
     }

--- a/src/vision.js
+++ b/src/vision.js
@@ -7,10 +7,13 @@ async function loadVision() {
     return;
   }
   const docRef = doc(collection(window.db, 'vision'), 'latest');
+  console.log('Vision docRef', docRef.path);
   try {
+    console.log('Checking cached vision text');
     const snapshot = await getDoc(docRef);
     let shouldUpdate = true;
     if (snapshot.exists()) {
+      console.log('Found cached vision', snapshot.data());
       const data = snapshot.data();
       if (data.updated && Date.now() - data.updated.toMillis() < 86400000) {
         shouldUpdate = false;
@@ -18,8 +21,10 @@ async function loadVision() {
       }
     }
     if (shouldUpdate) {
+      console.log('Fetching vision from GitHub');
       const resp = await fetch('https://raw.githubusercontent.com/nyhave/Stocks/main/VISION.md');
       const text = await resp.text();
+      console.log('Saving vision to Firestore');
       await setDoc(docRef, { text, updated: Timestamp.now() });
       window.visionText = text;
     }


### PR DESCRIPTION
## Summary
- add more console output in `firebase.js` for initialization and connection testing
- log Firestore document usage in `marketData.js` and `vision.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889aeb75c94832d9a2eee42b11a2f46