### PR TITLE
Improve error visibility for JS overlay

### DIFF
--- a/src/consoleCapture.js
+++ b/src/consoleCapture.js
@@ -87,4 +87,20 @@
   window.addEventListener('error', function(e) {
     addMessage('error', [e.message + ' (' + e.filename + ':' + e.lineno + ')']);
   });
+
+  window.addEventListener('unhandledrejection', function(e) {
+    let msg = '';
+    if (e.reason && e.reason.message) {
+      msg = e.reason.message;
+    } else if (typeof e.reason === 'string') {
+      msg = e.reason;
+    } else {
+      try {
+        msg = JSON.stringify(e.reason);
+      } catch {
+        msg = String(e.reason);
+      }
+    }
+    addMessage('error', ['Unhandled rejection: ' + msg]);
+  });
 })();


### PR DESCRIPTION
## Summary
- show unhandled promise rejections in the console overlay

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6889bf555c44832da98222324255cb54