### PR TITLE
Fix Firestore connection

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -39,8 +39,11 @@ function initFirebase() {
     // Analytics is optional and will fail on unsupported environments
     console.warn('Analytics init failed', err);
   }
-  // Enable fallback to long-polling in case WebSockets are blocked
-  const db = initializeFirestore(app, { experimentalAutoDetectLongPolling: true });
+  // Force long-polling in case WebSockets or streaming fetch are blocked
+  const db = initializeFirestore(app, {
+    experimentalForceLongPolling: true,
+    useFetchStreams: false,
+  });
   // Log detailed Firestore errors to help with debugging
   setLogLevel('debug');
   console.log('Firestore initialized');


### PR DESCRIPTION
## Summary
- enforce long polling in Firestore initialization so network environments that block WebSockets or fetch streaming can still connect

## Testing
- `node --check src/firebase.js`
- `node --check src/marketData.js`
- `node --check src/vision.js`


------
https://chatgpt.com/codex/tasks/task_e_6889c58bbf04832d97265f4d92183eaf