### PR TITLE
Enhance predict page

### DIFF
--- a/docs/PREDICT.md
+++ b/docs/PREDICT.md
@@ -84,6 +84,7 @@ The predict function combines a scoring model and rule set to ensure diversifica
 
 ### Client-side app
 The React app uses a lightweight JavaScript version called `clientPredict`. It offers three suggested portfolios based on risk level, cash percentage and a chosen segment bias. Each suggestion includes an estimated return so users can compare before selecting.
+The Predict page also features a slider to adjust the cash percentage and shows a short explanation for the selected segment bias so the user knows what each option means.
 
 ### Example call
 ```javascript

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -30,6 +30,7 @@ function DashboardPage({ lang }) {
   }, []);
 
   const t = window.locales[lang].labels;
+  const biasText = window.locales[lang].biasExplanation[bias];
   return (
     <div className="container">
       <h1>SmartPortfolio Dashboard</h1>
@@ -102,7 +103,23 @@ function PredictPage({ lang }) {
           </select>
         </label>
         <label htmlFor="cash">{t.cash}:
-          <input id="cash" type="number" min="0" max="100" value={cash} onChange={handleCashChange} />
+          <input
+            id="cash"
+            type="range"
+            min="0"
+            max="100"
+            step="1"
+            value={cash}
+            onChange={handleCashChange}
+          />
+          <input
+            type="number"
+            min="0"
+            max="100"
+            value={cash}
+            onChange={handleCashChange}
+            className="ml-2 w-16"
+          />
         </label>
         <label htmlFor="bias">{t.bias}:
           <select id="bias" value={bias} onChange={e => setBias(e.target.value)}>
@@ -112,6 +129,7 @@ function PredictPage({ lang }) {
             <option value="industrial">industrial</option>
           </select>
         </label>
+        <p className="text-sm italic">{t.biasExplanationLabel}: {biasText}</p>
         {cashError && <div className="error">{cashError}</div>}
         <button
           className="bg-blue-600 text-white text-xl px-6 py-3 rounded disabled:opacity-50 w-full sm:w-auto"

--- a/src/locales.js
+++ b/src/locales.js
@@ -4,6 +4,7 @@ window.locales = {
       risk: 'Risk',
       cash: 'Cash %',
       bias: 'Segment bias',
+      biasExplanationLabel: 'Bias explanation',
       lang: 'Language',
       predict: 'Predict',
       predicting: 'Predicting...',


### PR DESCRIPTION
## Summary
- improve Predict page UI
- add bias explanation text and slider for cash percent
- document bias explanation and slider

## Testing
- `node src/smartportfolio/dashboard.js`

------
https://chatgpt.com/codex/tasks/task_e_688a41c6d164832dbbee9566ac629e49