### PR TITLE
Improve dashboard view

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -20,6 +20,18 @@ function DashboardPage({ lang }) {
     getHoldingsWithValue(window.demoPortfolio)
   );
 
+  const sumWeights = window.demoPortfolio.holdings.reduce(
+    (a, b) => a + b.weight,
+    0
+  );
+  const cashWeight = 100 - sumWeights;
+  const cashValue =
+    window.demoPortfolio.cash !== undefined
+      ? window.demoPortfolio.cash
+      : (window.demoPortfolio.invested * cashWeight) / 100;
+  const totalValue = window.demoPortfolio.invested;
+  const activities = window.demoPortfolio.activities || [];
+
   React.useEffect(() => {
     window.updateHoldings = () => {
       setHoldings(getHoldingsWithValue(window.demoPortfolio));
@@ -33,9 +45,11 @@ function DashboardPage({ lang }) {
   return (
     <div className="container">
       <h1>SmartPortfolio Dashboard</h1>
+      <p>{t.totalValue}: {Math.round(totalValue).toLocaleString()}</p>
+      <p>{t.cashBalance}: {Math.round(cashValue).toLocaleString()}</p>
       <table className="transactions">
         <thead>
-          <tr><th>Ticker</th><th>{t.price}</th><th>%</th><th>Value (DDK)</th></tr>
+          <tr><th>Ticker</th><th>{t.price}</th><th>%</th><th>Value (DKK)</th></tr>
         </thead>
         <tbody>
           {holdings.map((h, i) => (
@@ -54,6 +68,18 @@ function DashboardPage({ lang }) {
           </tr>
         </tbody>
       </table>
+      {activities.length > 0 && (
+        <div>
+          <h2>{t.recentActivity}</h2>
+          <ul>
+            {activities.slice(-5).map((a, i) => (
+              <li key={i}>
+                {a.description}: {Math.round(a.amount).toLocaleString()}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/demoPortfolio.js
+++ b/src/demoPortfolio.js
@@ -1,5 +1,7 @@
 window.demoPortfolio = {
   invested: 1500000,
+  // Estimated cash position based on unused weight
+  cash: 95100,
   holdings: [
     { ticker: 'AMZN', weight: 7 },
     { ticker: 'AXP', weight: 7 },
@@ -16,5 +18,11 @@ window.demoPortfolio = {
     { ticker: 'PLTR', weight: 5.18 },
     { ticker: 'RR.L', weight: 6.28 },
     { ticker: 'SNOW', weight: 6.88 },
+  ],
+  // Sample recent portfolio activity
+  activities: [
+    { description: 'Bought NVDA', amount: 30000 },
+    { description: 'Sold GE', amount: -40000 },
+    { description: 'Bought AMZN', amount: 25000 }
   ]
 };

--- a/src/locales.js
+++ b/src/locales.js
@@ -17,6 +17,9 @@ window.locales = {
       show: 'Explain',
       improvement: 'Improvement',
       expectedReturn: 'Est. return',
+      totalValue: 'Total value',
+      cashBalance: 'Cash balance',
+      recentActivity: 'Recent activity',
       nav: {
         dashboard: 'Dashboard',
         predict: 'Predict',


### PR DESCRIPTION
## Summary
- add cash and activity data to demo portfolio
- add translations for total value, cash balance, and recent activity
- show total value, cash balance and recent activity in dashboard

## Testing
- `node -e "require('./src/smartportfolio/dashboard.js');" && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_688a41e45788832d86940c317d660daa