### PR TITLE
Add interactive history chart with metrics

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <!-- Firebase modular SDK imports are handled inside our modules -->
   <style>
     body {

--- a/src/locales.js
+++ b/src/locales.js
@@ -12,6 +12,7 @@ window.locales = {
       cost: 'Cost',
       price: 'Price',
       actions: { buy: 'Buy', sell: 'Sell' },
+      type: 'Type',
       cashError: 'Cash percentage must be between 0 and 100',
       select: 'Select',
       show: 'Explain',
@@ -28,7 +29,14 @@ window.locales = {
       initFirebase: 'Initialize Firebase',
       testConnection: 'Test connection',
       readMarket: 'Read market data',
-      updateTickers: 'Update tickers'
+      updateTickers: 'Update tickers',
+      range: 'Period',
+      highest: 'Highest value',
+      lowest: 'Lowest value',
+      change: 'Change %',
+      averageReturn: 'Average return %',
+      transactions: 'Transactions',
+      exportCsv: 'Export CSV'
     },
     biasExplanation: {
       none: 'No specific segment focus',


### PR DESCRIPTION
## Summary
- load Chart.js and expand history data
- implement interactive history page with chart, metrics and CSV export
- update i18n strings for new labels

## Testing
- `node src/smartportfolio/history.js`

------
https://chatgpt.com/codex/tasks/task_e_688a4181ca6c832db6ac57c0fe3f4136