### PR TITLE
Add PWA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,13 @@ The old Flutter demo has been removed. If no build is present, the page shows a 
 
 Sample command-line scripts demonstrating the portfolio logic are located in `src/smartportfolio/`. They can be executed with Node for quick experimentation.
 
+
+## Progressive Web App
+
+SmartPortfolio can be installed as a Progressive Web App on modern browsers. When installed, the app opens in its own window without the browser address bar.
+
+1. Open [SmartPortfolio](https://morninj.github.io/SmartPortfolio/) in your mobile or desktop browser.
+2. Use the browser's **Add to Home Screen** or **Install** option.
+3. Launch the app from the home screen to run it in standalone mode.
+
+The manifest and service worker needed for installation are included in the repository.

--- a/icon.svg
+++ b/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512">
+  <rect width="512" height="512" fill="#003366" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="256" fill="white">SP</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <meta name="theme-color" content="#003366" />
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" href="icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <title>SmartPortfolio</title>
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
@@ -94,5 +98,12 @@
   <script type="module" src="src/vision.js"></script>
   <script src="src/clientPredict.js"></script>
   <script type="text/babel" src="src/app.jsx"></script>
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register("service-worker.js");
+      });
+    }
+  </script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "SmartPortfolio",
+  "short_name": "SmartPortfolio",
+  "description": "Portfolio optimization web app / Porteføljeoptimering webapp",
+  "start_url": "./",
+  "display": "standalone",
+  "background_color": "#003366",
+  "theme_color": "#003366",
+  "icons": [
+    {
+      "src": "icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,27 @@
+const CACHE_NAME = 'smartportfolio-cache-v1';
+const urlsToCache = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/icon.svg',
+  '/src/app.jsx',
+  '/src/consoleCapture.js',
+  '/src/firebase.js',
+  '/src/locales.js',
+  '/src/demoPortfolio.js',
+  '/src/marketData.js',
+  '/src/vision.js',
+  '/src/clientPredict.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- include web app manifest and icon
- implement service worker to enable installability
- register the service worker and link manifest from HTML
- document installation as a PWA

## Testing
- `node --check service-worker.js`

------
https://chatgpt.com/codex/tasks/task_e_688a46e064a0832d9e45c01c24a387ef