### PR TITLE
Fix market data retrieval via CORS proxy

### DIFF
--- a/src/marketData.js
+++ b/src/marketData.js
@@ -19,8 +19,12 @@ async function loadMarketData() {
     }
     if (shouldUpdate) {
       const tickers = window.demoPortfolio.holdings.map(h => h.ticker).join(',');
+      const url =
+        `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${tickers}`;
+      // Yahoo Finance does not send CORS headers, so we use a public proxy
+      // to make the request browser-friendly.
       const resp = await fetch(
-        `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${tickers}`
+        `https://api.allorigins.win/raw?url=${encodeURIComponent(url)}`
       );
       const json = await resp.json();
       const quotes = {};


### PR DESCRIPTION
## Summary
- workaround for Yahoo Finance CORS issues by fetching through `api.allorigins.win`

## Testing
- `node -e "import('./src/marketData.js').then(()=>console.log('ok')).catch(e=>console.error(e));" --experimental-modules --no-warnings` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*

------
https://chatgpt.com/codex/tasks/task_e_688a587151b4832da6eb2ce9232f0492