### PR TITLE
Fix market data button

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -29,7 +29,7 @@ const firebaseConfig = {
 
 async function initFirebase() {
   if (window.db) {
-    return;
+    return window.db;
   }
   const app = initializeApp(firebaseConfig);
   try {
@@ -45,13 +45,16 @@ async function initFirebase() {
     experimentalForceLongPolling: true,
     useFetchStreams: false,
   });
+  // Expose the db instance immediately so other functions can use Firestore
+  // even if enabling persistence takes a bit longer
+  window.db = db;
   try {
     await enableIndexedDbPersistence(db);
   } catch (err) {
     console.warn('Offline persistence unavailable', err);
   }
   setLogLevel('error');
-  window.db = db;
+  return db;
 }
 
 async function checkFirestoreConnection(db) {

--- a/src/marketData.js
+++ b/src/marketData.js
@@ -3,8 +3,13 @@ import { collection, doc, getDoc, setDoc, Timestamp } from 'https://www.gstatic.
 
 async function loadMarketData() {
   if (!window.db) {
-    console.error('Firestore not initialized');
-    return;
+    if (window.initFirebase) {
+      await window.initFirebase();
+    }
+    if (!window.db) {
+      console.error('Firestore not initialized');
+      return;
+    }
   }
   const docRef = doc(collection(window.db, 'marketData'), 'latest');
   try {


### PR DESCRIPTION
## Summary
- initialize Firebase earlier so other code can use it
- auto-init if the market data button is used before Firebase setup

## Testing
- `node --check src/firebase.js`
- `node --check src/marketData.js`


------
https://chatgpt.com/codex/tasks/task_e_688a5afc0978832db0cbfa0f0135db61